### PR TITLE
removed most bugs

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -2,12 +2,11 @@ require_relative 'cell'
 require_relative 'ship'
 
 class Board
-  attr_accessor :cells, :coordinates, :column_check_2, :column_check_3, :row_check, :row_check_2, :row_check_3, :random_sub_coordinates, :random_cruiser_coordinates
+  attr_accessor :cells, :coordinates, :column_check_2, :column_check_3, :row_check_2, :row_check_3, :random_sub_coordinates, :random_cruiser_coordinates
 
   def initialize
     @coordinates = []
     @cells = create_cells
-    @row_check = []
     @column_check_2 = [['A1','B1'],['B1', 'C1'],['C1','D1'], ['A2','B2'],['B2', 'C2'],['C2','D2'],['A3','B3'],['B3', 'C3'],['C3','D3'],['A4','B4'],['B4', 'C4'],['C4','D4']]
     @column_check_3 = [['A1','B1', 'C1'],['A2','B2', 'C2'],['A3','B3', 'C3'],['A4','B4', 'C4'],['B1','C1','D1'],['B2','C2','D2'],['B3','C3','D3'], ['B4','C4','D4']]
     @row_check_2 = [['A1','A2'],['A2', 'A3'],['A3','A4'], ['B1','B2'],['B2', 'B3'],['B3','B4'],['C1','C2'],['C2', 'C3'],['C3','C4'],['D1','D2'],['D2', 'D3'],['D3','D4']]
@@ -43,9 +42,9 @@ class Board
 
   def consecutive_row_check(ship_object,coordinate_array)
     if coordinate_array.length == 2
-      @row_check_2.any? {|columns| columns == coordinate_array}
+      @row_check_2.any? {|rows| rows == coordinate_array}
     else
-      @row_check_3.any? {|columns| columns == coordinate_array}
+      @row_check_3.any? {|rows| rows == coordinate_array}
     end
   end
 
@@ -62,11 +61,9 @@ class Board
   end
 
   def place(ship_object,coordinate_array)
-    if valid_placement?(ship_object,coordinate_array) == true
       coordinate_array.each do |coordinate|
         @cells[coordinate].place_ship(ship_object)
       end
-    end
   end
 
   #Hardcoded arrays to build random coordinates for ships
@@ -75,7 +72,7 @@ class Board
     end
 
     def random_coordinates_cruiser_computer
-      @random_cruiser_coordinates = [@row_check_3, @row_check_3].sample(1).flatten!(1)
+      @random_cruiser_coordinates = [@column_check_3, @row_check_3].sample(1).flatten!(1)
     end
 
   def render(show_ship_board = false)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -42,29 +42,25 @@ class Game
 
 #Setup computer ships
   def generate_computer_sub_position
-      @computer_sub_position = @computer_board.random_coordinates_sub_computer.sample(1).flatten
+      @computer_sub_position = @computer_board.random_coordinates_sub_computer.sample(1).flatten!
   end
 
   def generate_computer_cruiser_position
-    @computer_cruiser_position = @computer_board.random_coordinates_cruiser_computer.sample(1).flatten
+    @computer_cruiser_position = @computer_board.random_coordinates_cruiser_computer.sample(1).flatten!
   end
 
   def validate_computer_sub_placement
-    if @computer_board.valid_placement?(@computer_sub, @computer_sub_position) == true
-      generate_computer_cruiser_position
+    if @computer_board.valid_placement?(@computer_sub, @computer_sub_position)
+      @computer_sub_position
     else
-      @computer_sub_position =[]
-      @computer_board.row_check = []
       generate_computer_sub_position
     end
   end
 
   def validate_computer_cruiser_placement
-    if @computer_board.valid_placement?(@computer_cruiser, @computer_cruiser_position) == true
-      puts 'The computer places its ships..'
+    if @computer_board.valid_placement?(@computer_cruiser, @computer_cruiser_position)
+      @computer_cruiser_position
     else
-      @computer_sub_position =[]
-      @computer_board.row_check = []
       generate_computer_cruiser_position
     end
   end
@@ -80,9 +76,9 @@ class Game
   def place_all_computer_ships
     generate_computer_sub_position
     validate_computer_sub_placement
+    place_computer_sub
     generate_computer_cruiser_position
     validate_computer_cruiser_placement
-    place_computer_sub
     place_computer_cruiser
     messages.computer_place_ships
     puts messages.display_computer_header
@@ -93,7 +89,7 @@ class Game
   def receive_player_sub_position_1
     messages.user_place_sub
     sub_position_1 = gets.chomp
-    if @player_board.valid_coordinate?(sub_position_1) == true
+    if @player_board.valid_coordinate?(sub_position_1)
       @player_sub_position << sub_position_1
       receive_player_sub_position_2
     else
@@ -103,47 +99,50 @@ class Game
   end
 
   def receive_player_sub_position_2
-    #message for player to enter 2nd position here
     sub_input_position_2 = gets.chomp
-    if @player_board.valid_coordinate?(sub_input_position_2) == true
+    if @player_board.valid_coordinate?(sub_input_position_2)
        @player_sub_position << sub_input_position_2
-       validate_sub_placement
     else
-      #add new messages for invalid 2nd coordinate and remove this one
       @messages.invalid_coordinates
       receive_player_sub_position_2
     end
   end
 
   def validate_sub_placement
-    if @player_board.valid_placement?(@player_sub, @player_sub_position) == true
-      place_player_sub
-      messages.user_place_sub_success
-      puts messages.display_player_header
-      puts display_player_board_hidden
-      receive_player_cruiser_position_1
+    if @player_board.valid_placement?(@player_sub, @player_sub_position)
+      @player_sub_position
     else
       messages.user_place_sub_failure
       @player_sub_position = []
-      @player_board.row_check = []
       receive_player_sub_position_1
     end
   end
 
   def place_player_sub
     @player_board.place(@player_sub, @player_sub_position)
-    @player_board.row_check = []
   end
 
   def place_all_player_ships
     receive_player_sub_position_1
+    validate_sub_placement
+    place_player_sub
+    messages.user_place_sub_success
+    puts messages.display_player_header
+    puts display_player_board_hidden
+    receive_player_cruiser_position_1
+    validate_cruiser_placement
+    place_player_cruiser
+    puts messages.display_player_header
+    puts display_player_board_hidden
+    puts "\n"
+    puts "Let the game begin.."
   end
 
 #Setup player_cruiser ----------------------------------------------------------
 def receive_player_cruiser_position_1
   messages.user_place_cruiser
   cruiser_position_1 = gets.chomp
-  if @player_board.valid_coordinate?(cruiser_position_1) == true
+  if @player_board.valid_coordinate?(cruiser_position_1)
     @player_cruiser_position << cruiser_position_1
     receive_player_cruiser_position_2
   else
@@ -153,41 +152,32 @@ def receive_player_cruiser_position_1
 end
 
 def receive_player_cruiser_position_2
-  #message for player to enter input here
   cruiser_position_2 = gets.chomp
-  if @player_board.valid_coordinate?(cruiser_position_2) == true
+  if @player_board.valid_coordinate?(cruiser_position_2)
     @player_cruiser_position << cruiser_position_2
     receive_player_cruiser_position_3
   else
-    #add new messages for invalid 2nd coordinate and remove this one
     @messages.invalid_coordinates
     receive_player_cruiser_position_2
   end
 end
 
 def receive_player_cruiser_position_3
-  #message for player to enter input here
   cruiser_position_3 = gets.chomp
   if @player_board.valid_coordinate?(cruiser_position_3)
     @player_cruiser_position << cruiser_position_3
-    validate_cruiser_placement
   else
-    #add new messages for invalid 2nd coordinate and remove this one
     @messages.invalid_coordinates
     receive_player_cruiser_position_2
   end
 end
 
 def validate_cruiser_placement
-  if @player_board.valid_placement?(@player_cruiser, @player_cruiser_position) == true
-    place_player_cruiser
-    messages.user_place_cruiser_success
-    puts messages.display_player_header
-    puts display_player_board_hidden
+  if @player_board.valid_placement?(@player_cruiser, @player_cruiser_position)
+    @player_cruiser_position
   else
     messages.user_place_cruiser_failure
     @player_cruiser_position = []
-    @player_board.row_check = []
     receive_player_cruiser_position_1
   end
 end
@@ -215,17 +205,17 @@ end
 def player_fires(player_shot)
   @computer_board.cells[player_shot].fire_upon
   puts player_fire_result(player_shot)
-  if player_fire_result(player_shot) == 'Hit!!'
+  if player_fire_result(player_shot) == "\nYou shoot..\nHit!!"
     puts player_fire_ship_hit_result(player_shot)
   end
 end
 
 def player_fire_result(player_shot)
-  @computer_board.cells[player_shot].ship.nil? ? 'Miss!' : 'Hit!!'
+  @computer_board.cells[player_shot].ship.nil? ? "\nYou shoot..\nMiss!" : "\nYou shoot..\nHit!!"
 end
 
 def player_fire_ship_hit_result(player_shot)
-  @computer_board.cells[player_shot].ship.health == 0 ? 'The ship was sunk!!' : 'The ship still floats..'
+  @computer_board.cells[player_shot].ship.health == 0 ? "\nComputer's ship was sunk!!" : "\nComputer's ship still floats.."
 end
 
 #Computer Attack Sequence
@@ -246,26 +236,26 @@ end
 def computer_fires(computer_shot)
   @player_board.cells[computer_shot].fire_upon
   puts computer_fire_result(computer_shot)
-  if computer_fire_result(computer_shot) == 'Computer hits you!!'
+  if computer_fire_result(computer_shot) == "\nComputer shoots...\nComputer hits you!!"
     puts computer_fire_ship_hit_result(computer_shot)
   end
 end
 
 def computer_fire_result(computer_shot)
-  @player_board.cells[computer_shot].ship.nil? ? 'Computer misses you!' : 'Computer hits you!!'
+  @player_board.cells[computer_shot].ship.nil? ? "\nComputer shoots...\nComputer misses you!!" : "\nComputer shoots...\nComputer hits you!!"
 end
 
 def computer_fire_ship_hit_result(computer_shot)
-  @player_board.cells[computer_shot].ship.health == 0 ? 'Computer sinks your ship!!' : 'Your ship still floats..'
+  @player_board.cells[computer_shot].ship.health == 0 ? "\nComputer sinks your ship!!" : "\nYour ship still floats.."
 end
 
 #Score Check Methods--------------------------------------------------
 def check_players_health
-  @player_sub.health == 0 && @player_cruiser.health == 0 ? true : 'Your turn!'
+  @player_sub.health == 0 && @player_cruiser.health == 0 ? true : "Your turn!\n"
 end
 
 def check_computers_health
-  @computer_sub.health == 0 && @computer_cruiser.health == 0 ? true : 'The computer takes a turn..'
+  @computer_sub.health == 0 && @computer_cruiser.health == 0 ? true : "The computer takes a turn..\n"
 end
 
 def check_game_result
@@ -308,7 +298,10 @@ def start_game
       messages.player_quits
       exit
     else
-      puts "Invalid option, please try again."
+      puts messages.invalid_input
+      start_game
     end
   end
 end
+
+#require 'pry';binding.pry

--- a/lib/messages.rb
+++ b/lib/messages.rb
@@ -15,12 +15,16 @@ class Messages
     puts "*** Goodbye ***"
   end
 
+  def invalid_input
+    "Invalid input, please try again."
+  end
+
   def computer_place_ships
     puts "Computer has placed its ships."
   end
 
   def user_place_sub
-    puts "Please place your submarine,length = 2"
+    puts "Please place your submarine,length = 2 (uppercase letters only)"
   end
 
   def user_place_sub_success
@@ -28,7 +32,7 @@ class Messages
   end
 
   def user_place_cruiser
-    puts "Please place your cruiser, length = 3"
+    puts "Please place your cruiser, length = 3 (uppercase letters only)"
   end
 
   def user_place_cruiser_success
@@ -41,14 +45,6 @@ class Messages
 
   def user_place_cruiser_failure
     puts "Uh oh, it looks like there were one or more errors with your cruiser placement.  Please try again"
-  end
-
-  def submarine_placement
-    puts "Enter the coordinates for your submarine"
-  end
-
-  def cruiser_placement
-    puts "Enter the coordinates for your cruiser"
   end
 
   def invalid_coordinates
@@ -66,7 +62,7 @@ class Messages
   end
 
   def player_shot
-  puts "Enter the coordinates for your shot"
+  puts "Enter the coordinates for your shot(uppercase letters only)"
   print ">>"
   end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -171,6 +171,34 @@ RSpec.describe Board do
         @board.place(cruiser, ["A2", "A3", "A4"])
         expect(@board.render(true)).to eql("  1 2 3 4\nA . S S S\nB . . . .\nC . . . .\nD . . . .\n")
       end
+
+      it 'renders a board that shows a ship that has been hit' do
+        cruiser = Ship.new("Cruiser", 3)
+        @board.place(cruiser, ["A1", "A2", "A3"])
+        cell_1 = @board.cells["A1"]
+        cell_1.fire_upon
+        expect(@board.render).to eql("  1 2 3 4\nA H . . .\nB . . . .\nC . . . .\nD . . . .\n")
+      end
+
+      it 'renders a board that shows when a cell missed' do
+        cruiser = Ship.new("Cruiser", 3)
+        @board.place(cruiser, ["A1", "A2", "A3"])
+        cell_1 = @board.cells["A4"]
+        cell_1.fire_upon
+        expect(@board.render).to eql("  1 2 3 4\nA . . . M\nB . . . .\nC . . . .\nD . . . .\n")
+      end
+
+      it 'renders a board that shows when a ship is sunk' do
+        cruiser = Ship.new("Cruiser", 3)
+        @board.place(cruiser, ["A1", "A2", "A3"])
+        cell_1 = @board.cells["A1"]
+        cell_2 = @board.cells["A2"]
+        cell_3 = @board.cells["A3"]
+        cell_1.fire_upon
+        cell_2.fire_upon
+        cell_3.fire_upon
+        expect(@board.render).to eql("  1 2 3 4\nA X X X .\nB . . . .\nC . . . .\nD . . . .\n")
+      end
     end
 
 end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Game do
     it 'displays a computer board after computers ship is hit' do
       @game.computer_board.place(Ship.new('cruiser',3),['A1','A2','A3'])
       @game.player_fires('A1')
-      expect(@game.player_fire_result('A1')).to eq("Hit!!")
-      expect(@game.player_fire_ship_hit_result('A1')).to eq('The ship still floats..')
+      expect(@game.player_fire_result('A1')).to eq("\nYou shoot..\nHit!!")
+      expect(@game.player_fire_ship_hit_result('A1')).to eq("\nComputer's ship still floats..")
       expect(@game.display_computer_board_hidden). to eq("  1 2 3 4\nA H S S .\nB . . . .\nC . . . .\nD . . . .\n")
       expect(@game.display_computer_board_visible). to eq("  1 2 3 4\nA H . . .\nB . . . .\nC . . . .\nD . . . .\n")
     end
@@ -99,7 +99,7 @@ RSpec.describe Game do
     it 'displays a computer board after a miss' do
       @game.computer_board.place(Ship.new('cruiser',3),['A1','A2','A3'])
       @game.player_fires('B2')
-      expect(@game.player_fire_result('B2')).to eq("Miss!")
+      expect(@game.player_fire_result('B2')).to eq("\nYou shoot..\nMiss!")
       expect(@game.display_computer_board_hidden). to eq("  1 2 3 4\nA S S S .\nB . M . .\nC . . . .\nD . . . .\n")
       expect(@game.display_computer_board_visible). to eq("  1 2 3 4\nA . . . .\nB . M . .\nC . . . .\nD . . . .\n")
     end
@@ -107,7 +107,7 @@ RSpec.describe Game do
     it 'displays a players board after a players ship is hit' do
       @game.player_board.place(Ship.new('cruiser',3),['A1','A2','A3'])
       @game.computer_fires('A1')
-      expect(@game.computer_fire_result('A1')).to eq('Computer hits you!!')
+      expect(@game.computer_fire_result('A1')).to eq("\nComputer shoots...\nComputer hits you!!")
       expect(@game.display_player_board_hidden). to eq("  1 2 3 4\nA H S S .\nB . . . .\nC . . . .\nD . . . .\n")
       expect(@game.display_player_board_visible). to eq("  1 2 3 4\nA H . . .\nB . . . .\nC . . . .\nD . . . .\n")
     end
@@ -115,7 +115,7 @@ RSpec.describe Game do
     it 'displays a players board after a players ship is missed' do
       @game.player_board.place(Ship.new('cruiser',3),['A1','A2','A3'])
       @game.computer_fires('A4')
-      expect(@game.computer_fire_result('A4')).to eq("Computer misses you!")
+      expect(@game.computer_fire_result('A4')).to eq("\nComputer shoots...\nComputer misses you!!")
       expect(@game.display_player_board_hidden). to eq("  1 2 3 4\nA S S S M\nB . . . .\nC . . . .\nD . . . .\n")
       expect(@game.display_player_board_visible). to eq("  1 2 3 4\nA . . . M\nB . . . .\nC . . . .\nD . . . .\n")
     end
@@ -123,11 +123,11 @@ RSpec.describe Game do
     it 'displays a computer board after computers ship is sunk' do
       @game.computer_board.place(Ship.new('sub',2),['A1','A2'])
       @game.player_fires('A1')
-      expect(@game.player_fire_ship_hit_result('A1')).to eq('The ship still floats..')
-      expect(@game.player_fire_result('A1')).to eq('Hit!!')
+      expect(@game.player_fire_ship_hit_result('A1')).to eq("\nComputer's ship still floats..")
+      expect(@game.player_fire_result('A1')).to eq("\nYou shoot..\nHit!!")
       @game.player_fires('A2')
-      expect(@game.player_fire_result('A2')).to eq('Hit!!')
-      expect(@game.player_fire_ship_hit_result('A2')).to eq('The ship was sunk!!')
+      expect(@game.player_fire_result('A2')).to eq("\nYou shoot..\nHit!!")
+      expect(@game.player_fire_ship_hit_result('A2')).to eq( "\nComputer's ship was sunk!!")
       expect(@game.display_computer_board_hidden). to eq("  1 2 3 4\nA X X . .\nB . . . .\nC . . . .\nD . . . .\n")
       expect(@game.display_computer_board_visible). to eq("  1 2 3 4\nA X X . .\nB . . . .\nC . . . .\nD . . . .\n")
     end
@@ -135,11 +135,11 @@ RSpec.describe Game do
     it 'displays a players board after a players ship is sunk' do
       @game.player_board.place(Ship.new('sub',2),['A1','A2'])
       @game.computer_fires('A1')
-      expect(@game.computer_fire_ship_hit_result('A1')).to eq('Your ship still floats..')
-      expect(@game.computer_fire_result('A1')).to eq('Computer hits you!!')
+      expect(@game.computer_fire_ship_hit_result('A1')).to eq("\nYour ship still floats..")
+      expect(@game.computer_fire_result('A1')).to eq("\nComputer shoots...\nComputer hits you!!")
       @game.computer_fires('A2')
-      expect(@game.computer_fire_result('A2')).to eq('Computer hits you!!')
-      expect(@game.computer_fire_ship_hit_result('A2')).to eq('Computer sinks your ship!!')
+      expect(@game.computer_fire_result('A2')).to eq("\nComputer shoots...\nComputer hits you!!")
+      expect(@game.computer_fire_ship_hit_result('A2')).to eq("\nComputer sinks your ship!!")
       expect(@game.display_player_board_hidden). to eq("  1 2 3 4\nA X X . .\nB . . . .\nC . . . .\nD . . . .\n")
       expect(@game.display_player_board_visible). to eq("  1 2 3 4\nA X X . .\nB . . . .\nC . . . .\nD . . . .\n")
     end
@@ -152,19 +152,10 @@ RSpec.describe Game do
       @computer_sub = sub
       @game.player_board.place(@computer_sub,['A1','A2'])
       @game.computer_fires('A1')
-      expect(@game.computer_fire_ship_hit_result('A1')).to eq('Your ship still floats..')
-      expect(@game.computer_fire_result('A1')).to eq('Computer hits you!!')
+      expect(@game.computer_fire_ship_hit_result('A1')).to eq("\nYour ship still floats..")
+      expect(@game.computer_fire_result('A1')).to eq("\nComputer shoots...\nComputer hits you!!")
       expect(sub.health).to eq(1)
-      expect(@game.check_players_health).to eq('Your turn!')
-    end
-
-    xit 'ends the game if player health is 0' do
-      sub = Ship.new('sub', 2)
-      @game.player_board.place(sub,['A1','A2'])
-      @game.computer_fires('A1')
-
-      @game.computer_fires('A2')
-      expect(@game.check_game_result).to eq("I have emerged victorious... as always.")
+      expect(@game.check_players_health).to eq( "Your turn!\n")
     end
 
     it 'displays a header for the player board' do


### PR DESCRIPTION
-bug occurs when user chooses the same coordinates x 2 in a row after a ship has already been placed in those coordinates.
Example:
1. user chooses ['A1', 'A2'] to place sub
2. user chooses ['A1','A2','A3] to place cruiser and is prevented from overwriting/overlapping sub and prompted to enter new coordinates
3. if user enters ['A1','A2','A3'] again, the sub is overwritten

-computer sub/cruiser placement occasionally not displaying...seems like it happens when the user enters bad coordinates for placement but not sure..
